### PR TITLE
Fix incorrect link clickable target area on Safari

### DIFF
--- a/assets/js/just-the-docs.js
+++ b/assets/js/just-the-docs.js
@@ -499,8 +499,7 @@ function navLink() {
 function scrollNav() {
   const targetLink = navLink();
   if (targetLink) {
-    const rect = targetLink.getBoundingClientRect();
-    document.getElementById('site-nav').scrollBy(0, rect.top - 3*rect.height);
+    targetLink.scrollIntoView();
     targetLink.removeAttribute('href');
   }
 }


### PR DESCRIPTION
not needed